### PR TITLE
Convert Mapbox GL JavaScript plugin to TypeScript Svelte component

### DIFF
--- a/src/data/evaluation_feature.ts
+++ b/src/data/evaluation_feature.ts
@@ -5,7 +5,7 @@ import type {VectorTileFeature} from '@mapbox/vector-tile';
 
 export type EvaluationFeature = {
     readonly type: 0 | 1 | 2 | 3 | 'Unknown' | 'Point' | 'LineString' | 'Polygon';
-    readonly id?: any;
+    readonly id?: number | string | undefined;
     properties: {
         [_: string]: any;
     };

--- a/src/data/feature_index.ts
+++ b/src/data/feature_index.ts
@@ -77,7 +77,7 @@ class FeatureIndex {
         this.serializedLayersCache = new Map();
     }
 
-    insert(feature: VectorTileFeature, geometry: Array<Array<Point>>, featureIndex: number, sourceLayerIndex: number, bucketIndex: number, layoutVertexArrayOffset: number = 0, envelopePadding: number = 0) {
+    insert(feature: VectorTileFeature, geometry: Array<Array<Point>>, featureIndex: number, sourceLayerIndex: number, bucketIndex: number, layoutVertexArrayOffset: number = 0, envelopePadding: number = 0): void {
         const key = this.featureIndexArray.length;
         this.featureIndexArray.emplaceBack(featureIndex, sourceLayerIndex, bucketIndex, layoutVertexArrayOffset);
 
@@ -138,13 +138,13 @@ class FeatureIndex {
         const matching = this.grid.query(bounds.min.x, bounds.min.y, bounds.max.x, bounds.max.y, queryPredicate);
         matching.sort(topDownFeatureComparator);
 
-        let elevationHelper = null;
+        let elevationHelper: DEMSampler | null = null;
         if (transform.elevation && matching.length > 0) {
             elevationHelper = DEMSampler.create(transform.elevation, this.tileID);
         }
 
         const result: QueryResult = {};
-        let previousIndex;
+        let previousIndex: number | undefined;
         for (let k = 0; k < matching.length; k++) {
             const index = matching[k];
 
@@ -153,7 +153,7 @@ class FeatureIndex {
             previousIndex = index;
 
             const match = this.featureIndexArray.get(index);
-            let featureGeometry = null;
+            let featureGeometry: Array<Array<Point>> | null = null;
 
             if (this.is3DTile) {
                 this.loadMatchingModelFeature(result, match, query, tilespaceGeometry, transform);


### PR DESCRIPTION
Add explicit types for variables, parameters, and return values in TypeScript files.

* **src/data/dem_data.ts**
  - Add explicit types for variables, parameters, and return values.
  - Include interfaces for Mapbox-specific objects or data structures.
  - Modify constructor and methods to use explicit types.

* **src/data/evaluation_feature.ts**
  - Update the type of `id` property in `EvaluationFeature` to `number | string | undefined`.

* **src/data/feature_index.ts**
  - Add explicit return type `void` for `insert` method.
  - Add explicit types for variables in `query` method.

## Summary by Sourcery

Update type annotations in TypeScript files for DEMData, EvaluationFeature, and FeatureIndex classes.